### PR TITLE
User activation functionality

### DIFF
--- a/app/controllers/activation_controller.rb
+++ b/app/controllers/activation_controller.rb
@@ -1,4 +1,8 @@
 class ActivationController < ApplicationController
   def show
+    user = User.find_by_activation_key(params[:key])
+    user.activated = true
+
+    user.save
   end
 end

--- a/app/controllers/activation_controller.rb
+++ b/app/controllers/activation_controller.rb
@@ -1,0 +1,4 @@
+class ActivationController < ApplicationController
+  def show
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,7 +1,7 @@
 class UserMailer < ApplicationMailer
   def activation_email
     @user = params[:user]
-    @url = "#{ENV['base_url']}/activate/#{@user.activation_code}"
+    @url = "#{ENV['base_url']}/activate/#{@user.activation_key}"
 
     mail(to: @user.email, subject: 'Activate Your Battleshift Account')
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,11 @@ class User < ApplicationRecord
   validates_uniqueness_of :email
 
   has_secure_password
+
+  before_save do
+    if self.activation_key.nil?
+      self.activation_key = rand(36**32).to_s(32).upcase
+      save
+    end
+  end
 end

--- a/app/views/activation/show.html.erb
+++ b/app/views/activation/show.html.erb
@@ -1,0 +1,1 @@
+<p>Thank you! Your account is now activated.</p>

--- a/app/views/user_mailer/activation_email.html.erb
+++ b/app/views/user_mailer/activation_email.html.erb
@@ -1,0 +1,1 @@
+<%= link_to 'Visit here to activate your account.', @url %>

--- a/app/views/user_mailer/activation_email.text.erb
+++ b/app/views/user_mailer/activation_email.text.erb
@@ -1,0 +1,2 @@
+Visit the below link to activate your account.
+<%= @url %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,6 @@
 <h1>Logged in as <%= current_user.name %></h1>
 <% unless current_user.activated %>
     <p>This account has not been activated yet. Please check your email.</p>
+<% else %>
+    <p>Status: Active</p>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   get '/register', to: 'users#new', as: 'registration'
   get '/dashboard', to: 'users#show'
+  get '/activate/:key', to: 'activation#show'
 
   resources :users, only: [:create]
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:name) { |n| "User #{n}" }
+    sequence(:email) { |n| "foo#{n}@foo.com" }
+    password "password"
+    password_confirmation "password"
+  end
+
+  factory :activated_user do
+    sequence(:name) { |n| "User #{n}" }
+    sequence(:email) { |n| "foo#{n}@foo.com" }
+    password "password"
+    password_confirmation "password"
+    activated true
+  end
+end

--- a/spec/features/user/user_can_activate_their_account_spec.rb
+++ b/spec/features/user/user_can_activate_their_account_spec.rb
@@ -12,6 +12,7 @@ context 'A user clicking the activate link in an email' do
     visit "/activate/#{user.activation_key}"
 
     expect(page).to have_content('Thank you! Your account is now activated.')
+    user.reload
 
     visit '/dashboard'
 

--- a/spec/features/user/user_can_activate_their_account_spec.rb
+++ b/spec/features/user/user_can_activate_their_account_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+context 'A user clicking the activate link in an email' do
+  let(:user) { create(:user) }
+  scenario 'can activate their account' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit '/dashboard'
+
+    expect(page).to have_content('This account has not been activated yet.')
+
+    visit "/activate/#{user.activation_key}"
+
+    expect(page).to have_content('Thank you! Your account is now activated.')
+
+    visit '/dashboard'
+
+    expect(page).to have_content("Logged in as #{user.name}")
+    expect(page).to_not have_content('This account has not been activated yet.')
+    expect(page).to have_content('Status: Active')
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe UserMailer, type: :mailer do
 
     it 'should send an activation email' do
       link = "#{ENV['base_url']}/activate/#{user.activation_key}"
-      expect(email.body.encoded).to have_link('Visit here to activate your account.', href: link)
+      expect(email.html_part.body.encoded).to have_link('Visit here to activate your account.', href: link)
+      expect(email.text_part.body.to_s).to include('Visit the below link to activate your account.')
+      expect(email.text_part.body.to_s).to include(link)
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,7 +1,15 @@
 require "rails_helper"
 
 RSpec.describe UserMailer, type: :mailer do
-  it 'should send an activation email' do
+  describe 'Activation Email' do
+    let(:user) { create(:user) }
+    let(:email) { UserMailer.with(user: user).activation_email }
 
+    it 'should send an activation email' do
+      expect(email.body.encoded).to have_link('Visit here to activate your account.')
+
+      link = find('a')
+      binding.pry
+    end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,5 +1,7 @@
 require "rails_helper"
 
 RSpec.describe UserMailer, type: :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it 'should send an activation email' do
+
+  end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -6,10 +6,8 @@ RSpec.describe UserMailer, type: :mailer do
     let(:email) { UserMailer.with(user: user).activation_email }
 
     it 'should send an activation email' do
-      expect(email.body.encoded).to have_link('Visit here to activate your account.')
-
-      link = find('a')
-      binding.pry
+      link = "#{ENV['base_url']}/activate/#{user.activation_key}"
+      expect(email.body.encoded).to have_link('Visit here to activate your account.', href: link)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ describe User, type: :model do
   it { is_expected.to validate_confirmation_of(:password) }
 
   it 'should not be active by default and have an activation key' do
-    user = User.new(name: 'a', email: 'b', password: '1', password_confirmation: '1')
+    user = User.create(name: 'a', email: 'b', password: '1', password_confirmation: '1')
 
     expect(user.activated).to be_falsey
     expect(user.activation_key).to_not be_nil

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ describe User, type: :model do
   it { is_expected.to validate_confirmation_of(:password) }
 
   it 'should not be active by default and have an activation key' do
-    user = User.create(name: 'a', email: 'b', password: '1', password_confirmation: '1')
+    user = create(:user)
 
     expect(user.activated).to be_falsey
     expect(user.activation_key).to_not be_nil


### PR DESCRIPTION
- User activation keys are generate
- Emails contain a link to the activation endpoint
- Activation endpoint changes User#active to true

@alexcutschall 
- Something to consider: Should the activation link be a "login link?" As in, when they click it. If they are not logged in, should it create the session as though they did? This would require some modification of the activate endpoint to make sure that the link can't be re-used, but that's easy to do. Not strictly necessary for this implementation, but as a user experience thing it's definitely something to think about. 
